### PR TITLE
Added support to SARIF and Gitlab reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,15 +54,19 @@ jobs:
 GitLab CI - Add the following job to your .gitlab-ci.yml file:
 ```yaml
 jira-scan:
-  stage: test
+  stage: dast
   image:
     name: spark1security/n0s1
     entrypoint: [""]
   script:
-    - n0s1 jira_scan --email "service_account@<YOUR_COMPANY>.atlassian.net" --api-key $JIRA_TOKEN --server "https://<YOUR_COMPANY>.atlassian.net"
+    - n0s1 jira_scan --email "service_account@<YOUR_COMPANY>.atlassian.net" --api-key $JIRA_TOKEN --server "https://<YOUR_COMPANY>.atlassian.net" --report-file gl-dast-report.json --report-format gitlab
     - apt-get update
     - apt-get -y install jq
-    - cat n0s1_report.json | jq
+    - cat gl-dast-report.json | jq
+  artifacts:
+    reports:
+      dast:
+        - gl-dast-report.json
 ```
 
 ## Want more? Check out Spark 1

--- a/src/n0s1/config/config.yaml
+++ b/src/n0s1/config/config.yaml
@@ -6,6 +6,7 @@ general_params:
   post_comment: false
   skip_comment: false
   show_matched_secret_on_logs: false
+  report_format: "n0s1"
 
 comment_params:
   bot_name: "n0s1 bot"

--- a/src/n0s1/n0s1.py
+++ b/src/n0s1/n0s1.py
@@ -3,6 +3,7 @@ import hashlib
 import logging
 import json
 import os
+import pathlib
 import re
 import sys
 import toml
@@ -13,6 +14,11 @@ try:
     import controllers.platform_controller as platform_controller
 except:
     import n0s1.controllers.platform_controller as platform_controller
+
+try:
+    import reporting.report_sarif as report_sarif
+except:
+    import n0s1.reporting.report_sarif as report_sarif
 
 
 global report_json, report_file, cfg
@@ -56,6 +62,14 @@ def init_argparse() -> argparse.ArgumentParser:
         default="n0s1_report.json",
         type=str,
         help="Output report file for the leaked secrets."
+    )
+    parent_parser.add_argument(
+        "--report-format",
+        dest="report_format",
+        nargs="?",
+        default="n0s1",
+        type=str,
+        help="Output report format. Supported formats: n0s1, SARIF, gitlab."
     )
     parent_parser.add_argument(
         "--post-comment",
@@ -161,13 +175,20 @@ def _sha1_hash(to_hash):
         raise "Unable to generate SHA-1 hash for input string"
 
 
-def _save_report():
+def _save_report(scan_text_result):
     global report_json, report_file
 
+    report_format = scan_text_result.get("scan_arguments", {}).get("report_format", "n0s1")
+
     try:
-        with open(report_file, "w") as f:
-            json.dump(report_json, f)
+        if report_format.lower().find("sarif".lower()) != -1:
+            github_report = report_sarif.n0s1_report_to_sarif_report(report_json)
+            github_report.write_report(report_file)
             return True
+        else:
+            with open(report_file, "w") as f:
+                json.dump(report_json, f)
+                return True
     except Exception as e:
         logging.error(e)
 
@@ -218,7 +239,7 @@ def report_leaked_secret(scan_text_result, controller):
                    "details": {"matched_regex_config": scan_text_result["matched_regex_config"], "platform": platform, "ticket_field": field}}
     if finding_id not in report_json["findings"]:
         report_json["findings"][finding_id] = new_finding
-        _save_report()
+        _save_report(scan_text_result)
     if post_comment:
         comment_template = cfg.get("comment_params", {}).get("message_template", "")
         bot_name = cfg.get("comment_params", {}).get("bot_name", "bot")
@@ -322,7 +343,12 @@ def main():
 
     datetime_now_obj = datetime.now(timezone.utc)
     date_utc = datetime_now_obj.strftime("%Y-%m-%d %H:%M:%S")
-    report_json = {"tool": "n0s1",
+    try:
+        init_file = pathlib.Path("__init__.py")
+        n0s1_version = re.search(r'^__version__ = [\'"]([^\'"]*)[\'"]', init_file.read_text(), re.M).group(1)
+    except:
+        n0s1_version = "0.0.1"
+    report_json = {"tool": {"name": "n0s1", "version": n0s1_version, "author": "Spark 1 Security"},
                    "scan_date": {"timestamp": datetime_now_obj.timestamp(),"date_utc": date_utc},
                    "regex_config": regex_config, "findings": {}}
     report_file = args.report_file
@@ -386,8 +412,14 @@ def main():
     else:
         show_matched_secret_on_logs = cfg.get("general_params", {}).get("show_matched_secret_on_logs", False)
 
+    if args.report_format:
+        report_format = args.report_format
+    else:
+        report_format = cfg.get("general_params", {}).get("report_format", False)
+
     scan_arguments = {"scan_comment": scan_comment, "post_comment": post_comment, "secret_manager": secret_manager,
-                      "contact_help": contact_help, "label": label, "show_matched_secret_on_logs": show_matched_secret_on_logs}
+                      "contact_help": contact_help, "label": label, "report_format": report_format,
+                      "show_matched_secret_on_logs": show_matched_secret_on_logs}
     scan(regex_config, controller, scan_arguments)
 
     logging.info("Done!")

--- a/src/n0s1/n0s1.py
+++ b/src/n0s1/n0s1.py
@@ -20,6 +20,11 @@ try:
 except:
     import n0s1.reporting.report_sarif as report_sarif
 
+try:
+    import reporting.report_gitlab as report_gitlab
+except:
+    import n0s1.reporting.report_gitlab as report_gitlab
+
 
 global report_json, report_file, cfg
 
@@ -184,6 +189,10 @@ def _save_report(scan_text_result):
         if report_format.lower().find("sarif".lower()) != -1:
             github_report = report_sarif.n0s1_report_to_sarif_report(report_json)
             github_report.write_report(report_file)
+            return True
+        elif report_format.lower().find("gitlab".lower()) != -1:
+            gitlab_report = report_gitlab.n0s1_report_to_gitlab_report(report_json)
+            gitlab_report.write_report(report_file)
             return True
         else:
             with open(report_file, "w") as f:

--- a/src/n0s1/reporting/report_gitlab.py
+++ b/src/n0s1/reporting/report_gitlab.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+
+import json
+import logging
+import os
+import sys
+
+
+class GitlabDASTReport:
+    def __init__(self, n0s1_data=None):
+        tool_name = n0s1_data.get("tool", {}).get("name", "")
+        tool_version = n0s1_data.get("tool", {}).get("version", "")
+        prvd = n0s1_data.get("tool", {}).get("author", "")
+        self.vulns: list[dict] = []
+        self.report = {
+            "version": "14.1.2",
+            "vulnerabilities": self.vulns,
+            "scan": {
+                "start_time": "2000-01-01T00:00:00",
+                "end_time": "2000-01-01T00:30:00",
+                "status": "success",
+                "type": "dast",
+                "scanner": {
+                    "id": tool_name,
+                    "name": f"{tool_name} secret scanner by {prvd} - version: [{tool_version}]",
+                    "url": "https://spark1.us/n0s1",
+                    "version": tool_version,
+                    "vendor": {
+                        "name": prvd,
+                    },
+                },
+            },
+        }
+        if n0s1_data:
+            self.add_vulns(n0s1_data)
+
+    def add_vulns(self, n0s1_data: dict):
+        findings = n0s1_data.get("findings", [])
+        for key in findings:
+            d = findings[key]
+            try:
+                finding_instance_id = d.get("id", "")
+                url = d.get("url", "")
+                secret = d.get("secret", "")
+                platform = d.get("details", {}).get("platform", "PM software")
+                field = d.get("details", {}).get("ticket_field", "ticket")
+                match = d.get("details", {}).get("matched_regex_config", {})
+                match_id = match.get("id", "")
+                match_description = match.get("description", "")
+
+                finding_message = f"Potential Secret Leak on {platform} {field}"
+                solution = f"\nPlease verify the {platform} ticket and conduct a thorough search for any sensitive data. If a data leak is confirmed, proceed to rotate the data and eliminate any sensitive information from the ticket. Ticket URL: {url}"
+
+                message = finding_message
+                message += f"\nDetails:\nSensitive data type: [{match_id}] - Description: [{match_description}]\nPlatform: [{platform}] - Field: [ticket {field}]\nSource: {url}"
+                message += f"\n000000000000000 Sensitive data found (redacted) 000000000000000\n{secret}\n000000000000000 Sensitive data found (redacted) 000000000000000"
+                finding_description = message.replace("<REDACTED>", "xxxxxxxxxxxx")
+
+                severity = "Info"
+                identifiers_name = match_description
+                identifiers_value = match_id
+
+                self.vulns.append(
+                    {
+                        "id": finding_instance_id,
+                        "category": "dast",
+                        "name": finding_message,
+                        "cve": "",
+                        "description": finding_description,
+                        "solution": solution,
+                        "evidence": {
+                            "source": {
+                                "id": "assert:Intel",
+                                "name": "n0s1 regex match"
+                            },
+                            "summary": (
+                                f"Evidence is supplied in form of n0s1 regex "
+                                "match in the response output below."
+                            ),
+                            "request": {
+                                "headers": [],
+                                "method": "Procedure",
+                                "body": "",
+                                "url": url
+                            },
+                            "response": {
+                                "headers": [],
+                                "reason_phrase": "OK",
+                                "status_code": 200,
+                                "body": secret,
+                            },
+                        },
+                        "severity": severity,
+                        "confidence": "low",
+                        "scanner": {
+                            "id": "n0s1",
+                            "name": "n0s1",
+                        },
+                        "identifiers": [
+                            {
+                                "type": "n0s1",
+                                "name": identifiers_name,
+                                "url": "https://spark1.us/n0s1",
+                                "value": identifiers_value
+                            }
+                        ],
+                        "links": [url],
+                        "location": {
+                            "hostname": url,
+                            "method": "",
+                            "param": "",
+                            "path": "",
+                        }
+                    }
+                )
+            except KeyError:
+                logging.info("Warning! Unexpected JSON format")
+                pass
+            except Exception as e:
+                logging.info(str(e))
+
+    def write_report(self, file="gl-dast-report.json") -> None:
+        with open(file, "w") as f:
+            f.write(json.dumps(self.report))
+
+
+def n0s1_report_to_gitlab_report(n0s1_report):
+    return GitlabDASTReport(n0s1_report)
+
+
+def n0s1_report_file_to_gitlab_report_file(input_report_path, output_report_path):
+    if os.path.exists(input_report_path):
+        with open(input_report_path) as f:
+            data = json.load(f)
+            logging.info(f"Parsing report file [{output_report_path}]...")
+            gitlab_report = GitlabDASTReport(data)
+            if len(gitlab_report.vulns) <= 0:
+                logging.info(f"No leaks found on file: [{output_report_path}].")
+            gitlab_report.write_gitlab_report(output_report_path)
+    else:
+        logging.info(f"Skipping report file: [{output_report_path}]")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(format="[%(levelname)s] %(message)s", level=logging.INFO)
+
+    INPUT_REPORT_PATH = "n0s1_report.json"
+    OUTPUT_REPORT_PATH = "gl-dast-report.json"
+
+    if len(sys.argv) > 1:
+        INPUT_REPORT_PATH = sys.argv[1]
+    if len(sys.argv) > 2:
+        OUTPUT_REPORT_PATH = sys.argv[2]
+
+    n0s1_report_file_to_gitlab_report_file(INPUT_REPORT_PATH, OUTPUT_REPORT_PATH)

--- a/src/n0s1/reporting/report_sarif.py
+++ b/src/n0s1/reporting/report_sarif.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+
+import json
+import logging
+import os
+import sys
+
+
+def _n0s1_rule_2_sarif_rule(n0s1_data):
+    sarif_rules = []
+    n0s1_rules = n0s1_data.get("regex_config", {}).get("rules", [])
+    for r in n0s1_rules:
+        id = r.get("id", "")
+        description = r.get("description", "")
+        sarif_r = {
+            "id": id,
+            "name": description,
+            "shortDescription": {
+                "text": description
+            },
+            "fullDescription": {
+                "text": f"{description}"
+            },
+            "defaultConfiguration": {
+                "level": "note"
+            },
+            "helpUri": "https://spark1.us/n0s1"
+        }
+        sarif_rules.append(sarif_r)
+    return sarif_rules
+
+
+class SarifReport:
+    def __init__(self, n0s1_data) -> None:
+        tool_name = n0s1_data.get("tool", {}).get("name", "")
+        tool_version = n0s1_data.get("tool", {}).get("version", "")
+        prvd = n0s1_data.get("tool", {}).get("author", "")
+        self.results: list[dict] = []
+        self.rules: list[dict] = []
+        self.seen_rules: set[str] = set()
+        self.rules = _n0s1_rule_2_sarif_rule(n0s1_data)
+
+        for rule in self.rules:
+            self.seen_rules.add(rule["id"])
+
+        self.report = {
+            "version": "2.1.0",
+            "$schema": "http://json.schemastore.org/sarif-2.1.0-rtm.4",
+            "runs": [
+                {
+                    "tool": {"driver": {"name": tool_name, "rules": self.rules, "version": tool_version,
+                                        "fullName": f"{tool_name} secret scanner by {prvd} - version: [{tool_version}]",
+                                        "informationUri": "https://github.com/spark1security/n0s1"}
+                             },
+                    "results": self.results,
+                }
+            ],
+        }
+        if n0s1_data:
+            self.add_vulns(n0s1_data)
+
+    def get_rule_index(self, rule_id):
+        index = 0
+        for r in self.rules:
+            index += 1
+            if rule_id.lower() == r.get("id", "").lower():
+                return index
+        return -1
+
+    def add_vulns(self, n0s1_data: dict):
+        findings = n0s1_data.get("findings", [])
+        for key in findings:
+            d = findings[key]
+            try:
+                url = d.get("url", "")
+                secret = d.get("secret", "")
+                platform = d.get("details", {}).get("platform", "PM software")
+                field = d.get("details", {}).get("ticket_field", "ticket")
+                ruleId = d.get("details", {}). get("matched_regex_config", {}).get("id", "")
+                level = "note"
+                match = d.get("details", {}).get("matched_regex_config", {})
+                match_id = match.get("id", "")
+                match_description = match.get("description", "")
+                ruleIndex = self.get_rule_index(ruleId)
+
+                if ruleId not in self.seen_rules:
+                    self.rules.append(
+                        {
+                            "id": ruleId,
+                            "name": f"Secret Leak - {ruleId}",
+                            "shortDescription": {"text": ruleId},
+                            "fullDescription": {"text": ruleId},
+                            "defaultConfiguration": {"level": "note"},
+                            "helpUri": "https://spark1.us/n0s1"
+                        }
+                    )
+
+                message = f"Potential Secret Leak on platform:[{platform}] field:[{field}]. Verify {url} and rotate credentials in the case the leak is confirmed."
+                message += f"\n\nid: {match_id}, description: [{match_description}]\nPlatform: {platform}. Field: ticket {field}"
+                message += f"\n############### Secret sanitized ###############\n{secret}\n############### Secret sanitized ###############"
+
+                self.results.append(
+                    {
+                        "ruleId": ruleId,
+                        "ruleIndex": ruleIndex,
+                        "message": {"text": message},
+                        "level": level,
+                        "locations": [
+                            {
+                                "physicalLocation": {
+                                    "artifactLocation": {"uri": "README.md", "uriBaseId": "ROOTPATH"},
+                                    "region": {
+                                        "startLine": 1,
+                                        "startColumn": 1,
+                                        "endLine": 1,
+                                        "endColumn": 1
+                                    }
+                                },
+                                "message": {
+                                    "text": url
+                                }
+                            }
+                        ]
+                    }
+                )
+            except KeyError:
+                logging.info("Warning! Unexpected JSON format")
+                pass
+            except Exception as e:
+                logging.info(str(e))
+
+    def write_report(self, file="report.sarif") -> None:
+        existing_sarif_data = None
+        if os.path.exists(file):
+            with open(file) as f:
+                existing_sarif_data = json.load(f)
+
+        result = None
+        if existing_sarif_data and "runs" in existing_sarif_data and "runs" in self.report:
+            result = existing_sarif_data
+            result["runs"] += self.report["runs"]
+        else:
+            result = self.report
+
+        with open(file, "w") as f:
+            f.write(json.dumps(result))
+            logging.info(f"Secret scanner report saved to: [{file}].")
+
+
+def n0s1_report_to_sarif_report(n0s1_report):
+    return SarifReport(n0s1_report)
+
+
+def n0s1_report_file_to_sarif_report_file(input_report_path, output_report_path):
+    if os.path.exists(input_report_path):
+        with open(input_report_path) as f:
+            data = json.load(f)
+            logging.info(f"Parsing report file [{input_report_path}]...")
+            sarif_report = n0s1_report_to_sarif_report(data)
+            if len(sarif_report.results) <= 0:
+                logging.info(f"No leaks found on file: [{input_report_path}].")
+            sarif_report.write_report(output_report_path)
+    else:
+        logging.info(f"Skipping report file: [{input_report_path}]")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(format="[%(levelname)s] %(message)s", level=logging.INFO)
+
+    INPUT_REPORT_PATH = "n0s1_report.json"
+    OUTPUT_REPORT_PATH = "n0s1_report.sarif"
+
+    if len(sys.argv) > 1:
+        INPUT_REPORT_PATH = sys.argv[1]
+    if len(sys.argv) > 2:
+        OUTPUT_REPORT_PATH = sys.argv[2]
+
+    n0s1_report_file_to_sarif_report_file(INPUT_REPORT_PATH, OUTPUT_REPORT_PATH)

--- a/src/n0s1/reporting/report_sarif.py
+++ b/src/n0s1/reporting/report_sarif.py
@@ -76,10 +76,10 @@ class SarifReport:
                 secret = d.get("secret", "")
                 platform = d.get("details", {}).get("platform", "PM software")
                 field = d.get("details", {}).get("ticket_field", "ticket")
-                ruleId = d.get("details", {}). get("matched_regex_config", {}).get("id", "")
                 level = "note"
                 match = d.get("details", {}).get("matched_regex_config", {})
                 match_id = match.get("id", "")
+                ruleId = match_id
                 match_description = match.get("description", "")
                 ruleIndex = self.get_rule_index(ruleId)
 

--- a/src/n0s1/reporting/report_sarif.py
+++ b/src/n0s1/reporting/report_sarif.py
@@ -95,9 +95,11 @@ class SarifReport:
                         }
                     )
 
-                message = f"Potential Secret Leak on platform:[{platform}] field:[{field}]. Verify {url} and rotate credentials in the case the leak is confirmed."
-                message += f"\n\nid: {match_id}, description: [{match_description}]\nPlatform: {platform}. Field: ticket {field}"
-                message += f"\n############### Secret sanitized ###############\n{secret}\n############### Secret sanitized ###############"
+                message = f"Potential Secret Leak on [{platform}]({url})."
+                message += f"\nDetails:\nSensitive data type: [{match_id}] - Description: [{match_description}]\nPlatform: [{platform}] - Field: [ticket {field}]\nSource: {url}"
+                message += f"\n000000000000000 Sensitive data found (redacted) 000000000000000\n{secret}\n000000000000000 Sensitive data found (redacted) 000000000000000"
+                message += f"\nPlease verify the [{platform} ticket]({url}) and conduct a thorough search for any sensitive data. If a data leak is confirmed, proceed to rotate the data and eliminate any sensitive information from the ticket."
+                message = message.replace("<REDACTED>", "xxxxxxxxxxxx")
 
                 self.results.append(
                     {
@@ -108,7 +110,7 @@ class SarifReport:
                         "locations": [
                             {
                                 "physicalLocation": {
-                                    "artifactLocation": {"uri": "README.md", "uriBaseId": "ROOTPATH"},
+                                    "artifactLocation": {"uri": "None", "uriBaseId": "ROOTPATH"},
                                     "region": {
                                         "startLine": 1,
                                         "startColumn": 1,


### PR DESCRIPTION
This PR adds support to [SARIF](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning) and [Gitlab reporting](https://docs.gitlab.com/ee/ci/yaml/artifacts_reports.html#artifactsreportsdast). That will allow n0s1 to run from Github Actions or GitLab CI and generate reports that either platform can ingest.

DevSecOps engineers can now track secret leaks flagged by n0s1, simply by using [GitHub Code scanning](https://docs.github.com/en/code-security/code-scanning/managing-your-code-scanning-configuration/about-the-tool-status-page#viewing-the-tool-status-page-for-a-repository) or [GitLab Vulnerability Report](https://docs.gitlab.com/ee/user/application_security/vulnerability_report/).