### PR TITLE
Fixed JQL reserved word bug on jira_controller.py

### DIFF
--- a/src/n0s1/controllers/jira_controller.py
+++ b/src/n0s1/controllers/jira_controller.py
@@ -32,7 +32,7 @@ class JiraControler():
                 issue_found = False
                 for key in projects:
                     project_found = True
-                    ql = f"project = {key}"
+                    ql = f"project = '{key}'"
                     for issue in self._client.search_issues(ql):
                         if issue:
                             issue_found = True
@@ -52,7 +52,7 @@ class JiraControler():
         if not self._client:
             return None, None, None, None, None
         for key in self._client.projects():
-            ql = f"project = {key}"
+            ql = f"project = '{key}'"
             logging.info(f"Scanning Jira project: [{key}]...")
             for issue in self._client.search_issues(ql):
                 url = issue.self.split('/rest/api')[0] + "/browse/" + issue.key;


### PR DESCRIPTION
This PR fixed the bug that causes the error: JQL Query: XXX is a reserved JQL word. The bug was reported on [this issue](https://github.com/spark1security/n0s1/issues/8).

Steps to reproduce:
Create a Jira project called AS. Add a ticket to the new project AS.
Scan Jira with n0s1:
n0s1 jira_scan --email user@spark1.us --server https://spark1us.atlassian.net
It will fail with the following message:
	response text = {"errorMessages":["Error in the JQL Query: 'AS' is a reserved JQL word. You must surround it in quotation marks to use it in a query. (line 1, character 11)"],"errors":{}}


