### PR TITLE
Example disable SSL in Confluence

### DIFF
--- a/src/n0s1/controllers/confluence_controller.py
+++ b/src/n0s1/controllers/confluence_controller.py
@@ -18,9 +18,9 @@ class ConfluenceControler():
         self._user = EMAIL
         self._password = TOKEN
         if EMAIL and len(EMAIL) > 0:
-            self._client = Confluence(url=SERVER, username=EMAIL, password=TOKEN)
+            self._client = Confluence(url=SERVER, username=EMAIL, password=TOKEN, verify_ssl=False)
         else:
-            self._client = Confluence(url=SERVER, token=TOKEN)
+            self._client = Confluence(url=SERVER, token=TOKEN, verify_ssl=False)
         return self.is_connected()
 
     def get_name(self):
@@ -40,7 +40,8 @@ class ConfluenceControler():
                     "GET",
                     url,
                     headers=headers,
-                    auth=auth
+                    auth=auth,
+                    verify=False
                 )
             else:
                 headers = {
@@ -50,7 +51,10 @@ class ConfluenceControler():
                 response = requests.request(
                     "GET",
                     url,
-                    headers=headers
+                    headers=headers,
+                    verify=False
+
+
                 )
         except Exception as e:
             logging.info(e)

--- a/src/n0s1/n0s1.py
+++ b/src/n0s1/n0s1.py
@@ -1,3 +1,7 @@
+# Disable all warnings from urllib about no ssl verfication
+import urllib3
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
 import argparse
 import hashlib
 import logging


### PR DESCRIPTION
Example how to disable the SSL-Verfication in `confluence_scan`, addresses #14 

**DO NOT accept this pull request**

What's missing is to make this optional via a commandline argument.


