### PR TITLE
Added insecure flag to skip SSL verification for Jira and Confluence

### DIFF
--- a/src/n0s1/config/config.yaml
+++ b/src/n0s1/config/config.yaml
@@ -9,6 +9,7 @@ general_params:
   report_format: "n0s1"
   timeout: null
   limit: null
+  insecure: false
 
 comment_params:
   bot_name: "n0s1 bot"

--- a/src/n0s1/controllers/confluence_controller.py
+++ b/src/n0s1/controllers/confluence_controller.py
@@ -23,19 +23,20 @@ class ConfluenceControler(hollow_controller.HollowController):
         EMAIL = config.get("email", "")
         TOKEN = config.get("token", "")
         TIMEOUT = config.get("timeout", -1)
+        VERIFY_SSL = not config.get("insecure", False)
         self._url = SERVER
         self._user = EMAIL
         self._password = TOKEN
         if EMAIL and len(EMAIL) > 0:
             if TIMEOUT and TIMEOUT > 0:
-                self._client = Confluence(url=SERVER, username=EMAIL, password=TOKEN, timeout=TIMEOUT)
+                self._client = Confluence(url=SERVER, verify_ssl=VERIFY_SSL, username=EMAIL, password=TOKEN, timeout=TIMEOUT)
             else:
-                self._client = Confluence(url=SERVER, username=EMAIL, password=TOKEN)
+                self._client = Confluence(url=SERVER, verify_ssl=VERIFY_SSL, username=EMAIL, password=TOKEN)
         else:
             if TIMEOUT and TIMEOUT > 0:
-                self._client = Confluence(url=SERVER, token=TOKEN, timeout=TIMEOUT)
+                self._client = Confluence(url=SERVER, verify_ssl=VERIFY_SSL, token=TOKEN, timeout=TIMEOUT)
             else:
-                self._client = Confluence(url=SERVER, token=TOKEN)
+                self._client = Confluence(url=SERVER, verify_ssl=VERIFY_SSL, token=TOKEN)
         return self.is_connected()
 
     def get_name(self):

--- a/src/n0s1/controllers/jira_controller.py
+++ b/src/n0s1/controllers/jira_controller.py
@@ -18,16 +18,18 @@ class JiraControler(hollow_controller.HollowController):
         EMAIL = config.get("email", "")
         TOKEN = config.get("token", "")
         TIMEOUT = config.get("timeout", -1)
+        VERIFY_SSL = not config.get("insecure", False)
+        options = {"verify": VERIFY_SSL}
         if EMAIL and len(EMAIL) > 0:
             if TIMEOUT and TIMEOUT > 0:
-                self._client = JIRA(SERVER, basic_auth=(EMAIL, TOKEN), timeout=TIMEOUT)
+                self._client = JIRA(SERVER, options=options, basic_auth=(EMAIL, TOKEN), timeout=TIMEOUT)
             else:
-                self._client = JIRA(SERVER, basic_auth=(EMAIL, TOKEN))
+                self._client = JIRA(SERVER, options=options, basic_auth=(EMAIL, TOKEN))
         else:
             if TIMEOUT and TIMEOUT > 0:
-                self._client = JIRA(SERVER, token_auth=TOKEN, timeout=TIMEOUT)
+                self._client = JIRA(SERVER, options=options, token_auth=TOKEN, timeout=TIMEOUT)
             else:
-                self._client = JIRA(SERVER, token_auth=TOKEN)
+                self._client = JIRA(SERVER, options=options, token_auth=TOKEN)
         return self.is_connected()
 
     def get_name(self):

--- a/src/n0s1/n0s1.py
+++ b/src/n0s1/n0s1.py
@@ -170,6 +170,12 @@ def init_argparse() -> argparse.ArgumentParser:
         type=str,
         help="The limit of the number of pages to return per HTTP request"
     )
+    parent_parser.add_argument(
+        "--insecure",
+        dest="insecure",
+        action="store_true",
+        help="Insecure mode. Ignore SSL certificate verification.",
+    )
     subparsers = parser.add_subparsers(
         help="Subcommands", dest="command", metavar="COMMAND"
     )
@@ -497,8 +503,14 @@ def main(callback=None):
     else:
         limit = cfg.get("general_params", {}).get("limit", None)
 
+    if args.insecure:
+        insecure = bool(args.insecure)
+    else:
+        insecure = cfg.get("general_params", {}).get("insecure", False)
+
     controler_config["timeout"] = timeout
     controler_config["limit"] = limit
+    controler_config["insecure"] = insecure
 
     TOKEN = None
     SERVER = None


### PR DESCRIPTION
Added insecure flag to skip SSL verification for Jira and Confluence scans.

This PR implements [this feature request](https://github.com/spark1security/n0s1/issues/14).