### PR TITLE
Changed get_data() to automatically reconnect client

### DIFF
--- a/src/n0s1/controllers/hollow_controller.py
+++ b/src/n0s1/controllers/hollow_controller.py
@@ -3,17 +3,35 @@ import logging
 
 class HollowController:
     def __init__(self):
-        self.client = None
+        self._client = None
+        self._config = None
+        self._check_connection_after = 200
+        self._requests_counter = 0
         self.log_message_callback = None
 
-    def set_config(self, config):
-        return self.is_connected()
+    def set_config(self, config=None):
+        if config:
+            self._config = config
+        return self._config is not None
 
     def set_log_message_callback(self, log_message_callback):
         self.log_message_callback = log_message_callback
 
     def get_name(self):
         return "Hollow"
+
+    def connect(self):
+        self._requests_counter += 1
+        if self._requests_counter > self._check_connection_after:
+            self._requests_counter = 0
+            if not self.is_connected():
+                # Force new connection
+                self._client = None
+
+        if not self._client:
+            if self.set_config():
+                return self.is_connected()
+        return True
 
     def is_connected(self):
         return False

--- a/src/n0s1/controllers/linear_controller.py
+++ b/src/n0s1/controllers/linear_controller.py
@@ -14,10 +14,10 @@ except:
 class LinearController(hollow_controller.HollowController):
     def __init__(self):
         super().__init__()
-        self._client = None
 
-    def set_config(self, config):
-        TOKEN = config.get("token", "")
+    def set_config(self, config=None):
+        super().set_config(config)
+        TOKEN = self._config.get("token", "")
         headers = {
             "Content-Type": "application/json",
             "Authorization": TOKEN,
@@ -55,7 +55,9 @@ class LinearController(hollow_controller.HollowController):
     def get_data(self, include_coments=False, limit=None):
         if not self._client:
             return {}
+        self.connect()
         for linear_data in self._client.get_issues_and_comments(20):
+            self.connect()
             for edge in linear_data.get("data", {}).get("issues", {}).get("edges", []):
                 item = edge.get("node", {})
                 url = item.get("url", "")

--- a/src/n0s1/controllers/slack_controller.py
+++ b/src/n0s1/controllers/slack_controller.py
@@ -12,12 +12,12 @@ except Exception:
 class SlackController(hollow_controller.HollowController):
     def __init__(self):
         super().__init__()
-        self._client = None
 
-    def set_config(self, config):
+    def set_config(self, config=None):
+        super().set_config(config)
         from slack_sdk import WebClient
         from slack_sdk.errors import SlackApiError
-        TOKEN = config.get("token", "")
+        TOKEN = self._config.get("token", "")
         self._client = WebClient(token=TOKEN)
         return self.is_connected()
 
@@ -75,6 +75,7 @@ class SlackController(hollow_controller.HollowController):
         try:
             channel_id, thread_ts = self.extract_channel_id_and_ts(issue)
             if comment and len(comment) > 0 and len(channel_id) > 0 and len(thread_ts) > 0:
+                self.connect()
                 response = self._client.chat_postMessage(
                     channel=channel_id,
                     text=comment,
@@ -121,6 +122,7 @@ class SlackController(hollow_controller.HollowController):
         from slack_sdk.errors import SlackApiError
         response = None
         try:
+            self.connect()
             response = self._client.search_messages(query=query, sort=sort, cursor=cursor)
         except SlackApiError as ex:
             message = str(ex) + f" client.search_messages()"

--- a/src/n0s1/controllers/wrike_controller.py
+++ b/src/n0s1/controllers/wrike_controller.py
@@ -8,13 +8,14 @@ try:
 except Exception:
     import n0s1.controllers.hollow_controller as hollow_controller
 
+
 class WrikeController(hollow_controller.HollowController):
     def __init__(self):
         super().__init__()
-        self._client = None
 
-    def set_config(self, config):
-        TOKEN = config.get("token", "")
+    def set_config(self, config=None):
+        super().set_config(config)
+        TOKEN = self._config.get("token", "")
         base_url = "https://www.wrike.com/api/v4"
         self._client = Wrike(base_url, TOKEN)
         return self.is_connected()
@@ -61,6 +62,7 @@ class WrikeController(hollow_controller.HollowController):
         if not self._client:
             return {}
 
+        self.connect()
         t = Tasks(self._client, parameters={"fields": ["description"]})
         response = t.query__tasks()
         tasks = {}
@@ -78,6 +80,7 @@ class WrikeController(hollow_controller.HollowController):
             comments = []
             if task_id := t.get("id", None):
                 if include_coments:
+                    self.connect()
                     comments_obj = Comments(self._client, [task_id])
                     response = comments_obj.query__tasks_taskId_comments()
                     json_data = {}
@@ -98,6 +101,7 @@ class WrikeController(hollow_controller.HollowController):
             return False
         comment = comment.replace("<REDACTED>", "**********")
         comment = comment.replace("\n", "<br>")
+        self.connect()
         comments_obj = Comments(self._client, [task_id], parameters={"text": comment, "plainText": False})
         if comments_obj:
             response = comments_obj.create__tasks_taskId_comments()


### PR DESCRIPTION
Added self.connect() call to all get_data() functions. It will re-instantiate a new client in the case the connection is lost.

This PR is related to this [issue](https://github.com/spark1security/n0s1/issues/26).

The scan may take longer for large sites (4 hours+) and the connection with the client might eventually timeout or be lost. This PR changes the get_data() function to check whether or not the client connection is still active. In the case the connection is lost, it will try to reconnect the client before trying to pull more data.